### PR TITLE
Add some tools for network visualization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 .pyre/
 
 .idea/
+
+data.js
+main.html

--- a/data/tojs.py
+++ b/data/tojs.py
@@ -1,0 +1,33 @@
+import json
+import pandas as pd
+import numpy as np
+from string import Template
+
+
+dataset = 'ht09_contact'  # infectious SFHH tij_InVS15
+# trim because vis.js can't scale
+slice_start = 2000
+slice_length = 400
+
+
+data = {}
+df = pd.read_csv(f'./{dataset}.txt', sep='\t', header=None, names=['source', 'destination', 'timestamp'])
+df = df.iloc[slice_start:slice_start + slice_length]
+
+with open('../vis/main.html.template', 'r') as f:
+    template = Template(f.read())
+html = template.safe_substitute(min_slider=df['timestamp'].min(), max_slider=df['timestamp'].max())
+with open('../vis/main.html', 'w') as f:
+    f.write(html)
+
+src = df['source']
+dst = df['destination']
+ts = df['timestamp']
+nodes = np.union1d(src.unique(), dst.unique())
+
+data['nodes'] = [{ 'id': int(node) } for node in nodes]
+data['edges'] = [{ 'from': int(s), 'to': int(d), 'ts': int(t) } for s, d, t in zip(src, dst, ts)]
+
+out = 'data = ' + json.dumps(data)
+with open('../vis/data.js', 'w') as f:
+    f.write(out)

--- a/vis/main.html.template
+++ b/vis/main.html.template
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>MDACN</title>
+    <script
+      type="text/javascript"
+      src="https://unpkg.com/vis-network/standalone/umd/vis-network.min.js"
+    ></script>
+    <style type="text/css">
+      #mynetwork {
+        width: 1800px;
+        height: 900px;
+        border: 1px solid lightgray;
+      }
+      .slidecontainer {
+        width: 100%;
+      }
+      #slider {
+        width: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="mynetwork"></div>
+
+    <div class="slidecontainer">
+      <input type="range" min="$min_slider" max="$max_slider" value="$min_slider" class="slider" id="slider">
+    </div>
+
+    <script type="text/javascript" src="./data.js"></script>
+    <script type="text/javascript" src="./main.js"></script>
+  </body>
+</html>

--- a/vis/main.js
+++ b/vis/main.js
@@ -1,0 +1,19 @@
+var nodes, edges, network;
+
+var nodes = new vis.DataSet(data["nodes"]);
+var edges = new vis.DataSet(data["edges"]);
+
+var container = document.getElementById("mynetwork");
+var options = {};
+var network = new vis.Network(container, {nodes: nodes, edges: edges}, options);
+
+var slider = document.getElementById("slider");
+slider.oninput = function() {
+  edges.forEach(x => {
+    if (x.ts == this.value) {
+      edges.update({id: x.id, color: 'red', width: 5})
+    } else {
+      edges.update({id: x.id, color: 'blue', width: 1})
+    }
+  })
+}

--- a/vis/tojs.py
+++ b/vis/tojs.py
@@ -11,13 +11,13 @@ slice_length = 400
 
 
 data = {}
-df = pd.read_csv(f'./{dataset}.txt', sep='\t', header=None, names=['source', 'destination', 'timestamp'])
+df = pd.read_csv(f'../data/{dataset}.txt', sep='\t', header=None, names=['source', 'destination', 'timestamp'])
 df = df.iloc[slice_start:slice_start + slice_length]
 
-with open('../vis/main.html.template', 'r') as f:
+with open('./main.html.template', 'r') as f:
     template = Template(f.read())
 html = template.safe_substitute(min_slider=df['timestamp'].min(), max_slider=df['timestamp'].max())
-with open('../vis/main.html', 'w') as f:
+with open('./main.html', 'w') as f:
     f.write(html)
 
 src = df['source']
@@ -29,5 +29,5 @@ data['nodes'] = [{ 'id': int(node) } for node in nodes]
 data['edges'] = [{ 'from': int(s), 'to': int(d), 'ts': int(t) } for s, d, t in zip(src, dst, ts)]
 
 out = 'data = ' + json.dumps(data)
-with open('../vis/data.js', 'w') as f:
+with open('./data.js', 'w') as f:
     f.write(out)


### PR DESCRIPTION
Added a folder `vis` with some network visualization tools, to help motivate the choice of the parameters (phi, beta etc) and help answer the "in what kind of networks the estimation works best" question.

Edit `dataset`, `slice_start`, `slice_length` in the python script, run it, open main.html in your browser, move the slider. Don't use a time slice of over 400 in length because it gets very slow.